### PR TITLE
Fix CI: run sys-test with --test-threads=1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           echo "${{ github.workspace }}/sdk/iCUESDK/redist/x64" >> "$GITHUB_PATH"
 
       - name: Run tests
-        run: cargo test -p sys-test
+        run: cargo test -p sys-test -- --test-threads=1
 
   test-macos:
     name: Test (macOS)
@@ -99,4 +99,4 @@ jobs:
           echo "DYLD_FRAMEWORK_PATH=${{ github.workspace }}/sdk_framework" >> "$GITHUB_ENV"
 
       - name: Run tests
-        run: cargo test -p sys-test
+        run: cargo test -p sys-test -- --test-threads=1


### PR DESCRIPTION
## Summary
- Adds `-- --test-threads=1` to `cargo test -p sys-test` on both Windows and macOS CI
- The iCUE SDK uses global state (single connection), so tests must run serially — concurrent `CorsairConnect` calls deadlock

## Context
Discovered in #14 — the diagnostic test + smoke test ran in parallel and hung for 60+ seconds before CI timed out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)